### PR TITLE
Add release-plan.yaml and CHANGELOG directory structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,0 @@
-Please see https://github.com/camaraproject/ReleaseManagement/blob/main/documentation/CHANGELOG_TEMPLATE.md when creating your first release and CHANGELOG.md entry.

--- a/CHANGELOG/README.md
+++ b/CHANGELOG/README.md
@@ -1,3 +1,3 @@
 # Changelog
 
-Release changelogs are organized by release cycle and will be updated during the automated release process (see https://github.com/camaraproject/ReleaseManagement/tree/main/documentation).
+Release changelogs are organized by release cycle and will be created and updated during the automated release process (see https://github.com/camaraproject/ReleaseManagement/tree/main/documentation).

--- a/CHANGELOG/README.md
+++ b/CHANGELOG/README.md
@@ -1,0 +1,3 @@
+# Changelog
+
+Release changelogs are organized by release cycle and will be updated during the automated release process (see https://github.com/camaraproject/ReleaseManagement/tree/main/documentation).

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,8 +13,3 @@
 # Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
 /CODEOWNERS @camaraproject/admins
 /MAINTAINERS.MD @camaraproject/admins
-
-# The following lines ensure that the release-management_reviewers team will automatically added as reviewers
-# if a pull requests is changing the CHANGELOG file (aka "release PR") and that such PRs can only be merged with an approval from a team member.
-/CHANGELOG.MD @camaraproject/release-management_reviewers
-/CHANGELOG.md @camaraproject/release-management_reviewers

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -25,11 +25,15 @@ repository:
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r3.4
-  identity_consent_management_release: r3.3
+  commonalities_release: r4.1
+  identity_consent_management_release: r4.1
 
 # APIs in this repository
 # Replace the placeholder below when planning a release:
 # - api_name: kebab-case identifier (used as filename in code/API_definitions/)
 # - target_api_status: draft | alpha | rc | public (draft allows no file yet)
 apis:
+  - api_name: placeholder-entry
+    target_api_version: 0.1.0
+    target_api_status: draft
+    main_contacts:

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -1,0 +1,35 @@
+# CAMARA Release Plan
+# This file declares release intentions for this repository.
+# It replaces manual wiki tracking with automated tooling.
+#
+# Update this file; CI validates it; releases are generated from this plan.
+# Docs: https://github.com/camaraproject/ReleaseManagement/tree/main/documentation
+
+repository:
+  # How this repository participates in CAMARA releases
+  # Options: independent (default) | meta-release
+  release_track: independent
+
+  # Uncomment and set when planning a meta-release participation:
+  # meta_release: Sync26
+
+  # Release tag -- first release for a repository is r1.1
+  # - New release cycle (increment first number, reset second to 1)
+  # - Progression in same cycle (increment second number)
+  target_release_tag: r1.1
+
+  # Release type being prepared (must be set before release can be triggered)
+  # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
+  target_release_type: none
+
+# Dependencies on Commonalities and ICM releases
+# Update per ReleaseManagement requirements for each release cycle
+dependencies:
+  commonalities_release: r3.4
+  identity_consent_management_release: r3.3
+
+# APIs in this repository
+# Replace the placeholder below when planning a release:
+# - api_name: kebab-case identifier (used as filename in code/API_definitions/)
+# - target_api_status: draft | alpha | rc | public (draft allows no file yet)
+apis:


### PR DESCRIPTION
#### What type of PR is this?

repository management

#### What this PR does / why we need it:

Prepares the Template_API_Repository for release automation adoption:
- Adds `release-plan.yaml` with `target_release_type: none` so new repositories created from this template have the release plan structure from day one
- Adds `CHANGELOG/` directory structure (`CHANGELOG/README.md`) matching the release automation convention
- Updates `CODEOWNERS` (removes CHANGELOG-specific reviewers)
- Removes legacy `CHANGELOG.md` in favor of the new directory-based structure

Codeowners of new repos update `target_release_type` and the `apis` section when they start planning their first release.

#### Which issue(s) this PR fixes:

Related: camaraproject/tooling#82 (caller workflow rollout not yet included)

#### Special notes for reviewers:

The caller workflow (`.github/workflows/release-automation.yml`) is not yet included — it will be added once the release automation reaches RC status. Rulesets are applied separately via the admin script (`apply-release-rulesets.sh`), not inherited from the template.

#### Changelog input

```
release-note
Add release-plan.yaml and CHANGELOG directory structure for release automation
```

#### Additional documentation

```
docs
```